### PR TITLE
Lighten up arithmetic operations

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -115,16 +115,12 @@ func SubtractMatrix(m, n Matrix) Matrix {
 		panic("matrix: can't subtract different sized matricies")
 	}
 
-	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
-		return m.Data[x][y] - n.Data[x][y]
-	})
+	return AddMatrix(m, Scale(n, -1))
 }
 
 // Subtract does scalar subtraction.
 func Subtract(m Matrix, n float64) Matrix {
-	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
-		return m.Data[x][y] - n
-	})
+	return Add(m, -n)
 }
 
 // HadamardProduct does Hadamard Product (entrywise).

--- a/funcs.go
+++ b/funcs.go
@@ -94,7 +94,7 @@ func Det(m Matrix) float64 {
 // AddMatrix adds 2 matrices together.
 func AddMatrix(m, n Matrix) Matrix {
 	if m.Rows != n.Rows || m.Columns != n.Columns {
-		panic("matrix: can't add different sized matricies")
+		panic("matrix: can't add different sized matrices")
 	}
 
 	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
@@ -112,7 +112,7 @@ func Add(m Matrix, n float64) Matrix {
 // SubtractMatrix subtracts 2 matrices.
 func SubtractMatrix(m, n Matrix) Matrix {
 	if m.Rows != n.Rows || m.Columns != n.Columns {
-		panic("matrix: can't subtract different sized matricies")
+		panic("matrix: can't subtract different sized matrices")
 	}
 
 	return AddMatrix(m, Scale(n, -1))
@@ -126,7 +126,7 @@ func Subtract(m Matrix, n float64) Matrix {
 // HadamardProduct does Hadamard Product (entrywise).
 func HadamardProduct(m Matrix, n Matrix) Matrix {
 	if m.Columns != n.Columns || m.Rows != n.Rows {
-		panic("matrix: matricies must have the same shape")
+		panic("matrix: matrices must have the same shape")
 	}
 
 	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
@@ -137,7 +137,7 @@ func HadamardProduct(m Matrix, n Matrix) Matrix {
 // Multiply does matrix product.
 func Multiply(m, n Matrix) Matrix {
 	if m.Columns != n.Rows {
-		panic("matrix: rows must match with columns of matricies")
+		panic("matrix: rows must match with columns of matrices")
 	}
 
 	return Map(New(m.Rows, n.Columns, nil), func(_ float64, x, y int) float64 {

--- a/funcs.go
+++ b/funcs.go
@@ -44,9 +44,7 @@ func Scale(m Matrix, a float64) Matrix {
 
 // Divide does scalar division.
 func Divide(m Matrix, a float64) Matrix {
-	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
-		return m.Data[x][y] / a
-	})
+	return Scale(m, 1/a)
 }
 
 // Sum gives the sum of the elements in the matrix.

--- a/funcs.go
+++ b/funcs.go
@@ -42,11 +42,6 @@ func Scale(m Matrix, a float64) Matrix {
 	})
 }
 
-// Divide does scalar division.
-func Divide(m Matrix, a float64) Matrix {
-	return Scale(m, 1/a)
-}
-
 // Sum gives the sum of the elements in the matrix.
 func Sum(m Matrix) float64 {
 	return m.Fold(func(accumulator, val float64, x, y int) float64 {
@@ -107,20 +102,6 @@ func Add(m Matrix, n float64) Matrix {
 	return Map(New(m.Rows, m.Columns, nil), func(val float64, x, y int) float64 {
 		return m.Data[x][y] + n
 	})
-}
-
-// SubtractMatrix subtracts 2 matrices.
-func SubtractMatrix(m, n Matrix) Matrix {
-	if m.Rows != n.Rows || m.Columns != n.Columns {
-		panic("matrix: can't subtract different sized matrices")
-	}
-
-	return AddMatrix(m, Scale(n, -1))
-}
-
-// Subtract does scalar subtraction.
-func Subtract(m Matrix, n float64) Matrix {
-	return Add(m, -n)
 }
 
 // HadamardProduct does Hadamard Product (entrywise).

--- a/matrix.go
+++ b/matrix.go
@@ -99,7 +99,7 @@ func (m Matrix) Scale(a float64) Matrix {
 
 // Divide does scalar multiplication
 func (m Matrix) Divide(a float64) Matrix {
-	return Divide(m, a)
+	return Scale(m, 1/a)
 }
 
 // Sum gives the sum of the elements in the matrix
@@ -119,12 +119,12 @@ func (m Matrix) Add(a float64) Matrix {
 
 // SubtractMatrix subtracts 2 matrices
 func (m Matrix) SubtractMatrix(n Matrix) Matrix {
-	return SubtractMatrix(m, n)
+	return AddMatrix(m, Scale(n, -1))
 }
 
 // Subtract does scalar subtraction
 func (m Matrix) Subtract(a float64) Matrix {
-	return Subtract(m, a)
+	return Add(m, -a)
 }
 
 // HadamardProduct does Hadamard product (entrywise)


### PR DESCRIPTION
Subtraction and division can be expressed through addition and multiplication respectively; this PR exploits said properties. Higher-level subtraction/division functions use sums/products under the hood. In addition, a few typos are corrected.